### PR TITLE
update SMI defaults

### DIFF
--- a/Server/WebApi/Services/Service.Metadata.cs
+++ b/Server/WebApi/Services/Service.Metadata.cs
@@ -2039,7 +2039,7 @@ public static class Metadata
                         DataType = "int",
                         DefaultValue = 13,
                         Minimum = 1,
-                        Maximum = 50
+                        Maximum = 300
                     },
                     new IndicatorParamConfig {
                         DisplayName = "First Smooth Periods",
@@ -2047,7 +2047,7 @@ public static class Metadata
                         DataType = "int",
                         DefaultValue = 25,
                         Minimum = 1,
-                        Maximum = 30
+                        Maximum = 300
                     },
                     new IndicatorParamConfig {
                         DisplayName = "Second Smooth Periods",
@@ -2055,7 +2055,7 @@ public static class Metadata
                         DataType = "int",
                         DefaultValue = 2,
                         Minimum = 1,
-                        Maximum = 30
+                        Maximum = 50
                     },
                     new IndicatorParamConfig {
                         DisplayName = "Signal Periods",
@@ -2063,7 +2063,7 @@ public static class Metadata
                         DataType = "int",
                         DefaultValue = 9,
                         Minimum = 1,
-                        Maximum = 30
+                        Maximum = 50
                     }
                 },
                 Results = new List<IndicatorResultConfig>{

--- a/Server/WebApi/Services/Service.Metadata.cs
+++ b/Server/WebApi/Services/Service.Metadata.cs
@@ -2037,7 +2037,7 @@ public static class Metadata
                         DisplayName = "Lookback Periods",
                         ParamName = "lookbackPeriods",
                         DataType = "int",
-                        DefaultValue = 10,
+                        DefaultValue = 13,
                         Minimum = 1,
                         Maximum = 50
                     },
@@ -2045,7 +2045,7 @@ public static class Metadata
                         DisplayName = "First Smooth Periods",
                         ParamName = "firstSmoothPeriods",
                         DataType = "int",
-                        DefaultValue = 3,
+                        DefaultValue = 25,
                         Minimum = 1,
                         Maximum = 30
                     },
@@ -2053,7 +2053,7 @@ public static class Metadata
                         DisplayName = "Second Smooth Periods",
                         ParamName = "secondSmoothPeriods",
                         DataType = "int",
-                        DefaultValue = 3,
+                        DefaultValue = 2,
                         Minimum = 1,
                         Maximum = 30
                     },
@@ -2061,7 +2061,7 @@ public static class Metadata
                         DisplayName = "Signal Periods",
                         ParamName = "signalPeriods",
                         DataType = "int",
-                        DefaultValue = 3,
+                        DefaultValue = 9,
                         Minimum = 1,
                         Maximum = 30
                     }


### PR DESCRIPTION
Done when:

- [x] use Blau’s “basic configuration” values for defaults, per https://github.com/DaveSkender/Stock.Indicators/discussions/625#discussioncomment-6870639